### PR TITLE
Experimental support for Structured Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $wgDiscordSendMethod = "curl";
 ```
 
 5) Enjoy the notifications in your Discord room!
-	
+
 ## Additional options
 
 These options can be set after including your plugin in your `localSettings.php` file.
@@ -157,6 +157,8 @@ $wgDiscordNotificationEditedArticle = true;
 $wgDiscordNotificationFileUpload = true;
 // Article protection settings changed
 $wgDiscordNotificationProtectedArticle = true;
+// Action on Flow Boards (experimental)
+$wgDiscordNotificationFlow = true;
 ```
 
 ## Additional MediaWiki URL Settings

--- a/extension.json
+++ b/extension.json
@@ -58,6 +58,11 @@
 			[
 				"DiscordNotifications::discord_user_groups_changed"
 			]
+		],
+		"APIFlowAfterExecute": [
+			[
+				"DiscordNotifications::discord_api_flow_after_execute"
+			]
 		]
 	},
 	"config": {
@@ -91,6 +96,7 @@
 		"DiscordNotificationProtectedArticle": true,
 		"DiscordNotificationShowSuppressed": true,
 		"DiscordNotificationUserGroupsChanged": true,
+		"DiscordNotificationFlow": true,
 		"DiscordIncludeDiffSize": true,
 		"DiscordShowNewUserEmail": true,
 		"DiscordShowNewUserFullName": true,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,5 +30,22 @@
     "discordnotifications-block-user-list": "List of all blocks",
     "discordnotifications-summary": "Summary: ",
     "discordnotifications-view-user-rights": "View or manage user rights",
-    "discordnotifications-change-user-groups": "%s has changed user groups for %s. New groups: %s"
+    "discordnotifications-change-user-groups": "%s has changed user groups for %s. New groups: %s",
+    "discordnotifications-flow-edit-header": "💬 %s has edited a board description %s",
+    "discordnotifications-flow-edit-post": "💬 %s has edited a post on %s",
+    "discordnotifications-flow-edit-title": "💬 %s has changed the topic title to %s on %s",
+    "discordnotifications-flow-edit-topic-summary": "💬 %s has edited topic summary on %s",
+    "discordnotifications-flow-lock-topic": "💬 %s has %s the topic %s",
+    "discordnotifications-flow-lock-topic-lock": "resolved",
+    "discordnotifications-flow-lock-topic-unlock": "reopened",
+    "discordnotifications-flow-moderate-post": "💬 %s has %s a post on topic %s",
+    "discordnotifications-flow-moderate-topic": "💬 %s has %s the topic %s",
+    "discordnotifications-flow-moderate-hide": "hidden",
+    "discordnotifications-flow-moderate-unhide": "unhidden",
+    "discordnotifications-flow-moderate-suppress": "suppressed",
+    "discordnotifications-flow-moderate-unsuppress": "unsuppressed",
+    "discordnotifications-flow-moderate-delete": "deleted",
+    "discordnotifications-flow-moderate-undelete": "undeleted",
+    "discordnotifications-flow-new-topic": "💬 %s has created topic %s on %s",
+    "discordnotifications-flow-reply": "💬 %s has replied in %s"
 }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -1,0 +1,34 @@
+{
+    "@metadata": {
+        "authors": [
+            "lens0021"
+        ]
+    },
+    "discordnotifications-block": "차단",
+    "discordnotifications-groups": "권한",
+    "discordnotifications-talk": "토론",
+    "discordnotifications-contribs": "기여",
+    "discordnotifications-edit": "편집",
+    "discordnotifications-delete": "삭제",
+    "discordnotifications-history": "역사",
+    "discordnotifications-diff": "차이",
+    "discordnotifications-bytes": "바이트",
+    "discordnotifications-article-saved": "📝 %s 님이 %s: %s %s",
+    "discordnotifications-article-saved-minor-edits": "사소하게 편집함",
+    "discordnotifications-article-saved-edit": "편집함",
+    "discordnotifications-article-created": "📄 %s 님이 %s 문서를 새로 만듦. %s",
+    "discordnotifications-file-namespace": "파일",
+    "discordnotifications-article-deleted": "❌ %s 님이 %s 문서를 삭제함. 이유: %s",
+    "discordnotifications-article-moved": "➡ %s 님이 %s 문서를 %s 문서로 이동함. 이유: %s",
+    "discordnotifications-article-protected": "🔒 %s 님이 %s 문서의 %s. 이유: %s",
+    "discordnotifications-article-protected-change": "보호 수준을 변경함",
+    "discordnotifications-article-protected-remove": "보호를 제거함",
+    "discordnotifications-new-user": "👥 새 사용자 %s 님이 가입함. %s",
+    "discordnotifications-file-uploaded": "📤 %s 님이 새 파일 <%s|%s>을 업로드함. (포맷: %s, 크기: %s MB, 요약: %s)",
+    "discordnotifications-block-user": "🚫 %s 님이 %s을 차단함(%s). 차단 기한: %s. %s",
+    "discordnotifications-block-user-reason": "이유:",
+    "discordnotifications-block-user-list": "차단 목록",
+    "discordnotifications-summary": "요약: ",
+    "discordnotifications-view-user-rights": "View or manage user rights",
+    "discordnotifications-change-user-groups": "%s has changed user groups for %s. New groups: %s"
+}


### PR DESCRIPTION
This will add a hook for [Structured Discussions], but with limitations:

- Only works with actions from Javascript UI; non Javascript actions will be ignored. This happens in browsers do not support Javascript.
- The title of topics is only displayed as UUID (for instance, `Topic:V2x4eocpudm5wtz4`) rather than a human readable ones.

In addition, my source editor removes some whitespaces automatically. But it affects nothing, don't worry about it.

[Structured Discussions]: https://www.mediawiki.org/wiki/Structured_Discussions