### PR TITLE
Experimental support for Structured Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $wgDiscordSendMethod = "curl";
 ```
 
 5) Enjoy the notifications in your Discord room!
-	
+
 ## Additional options
 
 These options can be set after including your plugin in your `localSettings.php` file.
@@ -157,6 +157,8 @@ $wgDiscordNotificationEditedArticle = true;
 $wgDiscordNotificationFileUpload = true;
 // Article protection settings changed
 $wgDiscordNotificationProtectedArticle = true;
+// Action on Flow Boards (experimental)
+$wgDiscordNotificationFlow = true;
 ```
 
 ## Additional MediaWiki URL Settings

--- a/extension.json
+++ b/extension.json
@@ -58,6 +58,11 @@
 			[
 				"DiscordNotifications::discord_user_groups_changed"
 			]
+		],
+		"APIFlowAfterExecute": [
+			[
+				"DiscordNotifications::discord_api_flow_after_execute"
+			]
 		]
 	},
 	"config": {
@@ -91,6 +96,7 @@
 		"DiscordNotificationProtectedArticle": true,
 		"DiscordNotificationShowSuppressed": true,
 		"DiscordNotificationUserGroupsChanged": true,
+		"DiscordNotificationFlow": true,
 		"DiscordIncludeDiffSize": true,
 		"DiscordShowNewUserEmail": true,
 		"DiscordShowNewUserFullName": true,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,5 +30,22 @@
     "discordnotifications-block-user-list": "List of all blocks",
     "discordnotifications-summary": "Summary: ",
     "discordnotifications-view-user-rights": "View or manage user rights",
-    "discordnotifications-change-user-groups": "%s has changed user groups for %s. New groups: %s"
+    "discordnotifications-change-user-groups": "%s has changed user groups for %s. New groups: %s",
+    "discordnotifications-flow-edit-header": "💬 %s has edited a board description %s",
+    "discordnotifications-flow-edit-post": "💬 %s has edited a post on %s",
+    "discordnotifications-flow-edit-title": "💬 %s has changed the topic title to %s on %s",
+    "discordnotifications-flow-edit-topic-summary": "💬 %s has edited topic summary on %s",
+    "discordnotifications-flow-lock-topic": "💬 %s has %s the topic %s",
+    "discordnotifications-flow-lock-topic-lock": "resolved",
+    "discordnotifications-flow-lock-topic-unlock": "reopened",
+    "discordnotifications-flow-moderate-post": "💬 %s has %s a post on topic %s",
+    "discordnotifications-flow-moderate-topic": "💬 %s has %s the topic %s",
+    "discordnotifications-flow-moderate-hide": "hidden",
+    "discordnotifications-flow-moderate-unhide": "unhidden",
+    "discordnotifications-flow-moderate-suppress": "suppressed",
+    "discordnotifications-flow-moderate-unsuppress": "unsuppressed",
+    "discordnotifications-flow-moderate-delete": "deleted",
+    "discordnotifications-flow-moderate-undelete": "undeleted",
+    "discordnotifications-flow-new-topic": "💬 %s has created topic %s on %s",
+    "discordnotifications-flow-reply": "💬 %s has replied in %s"
 }


### PR DESCRIPTION
This will add a hook for [Structured Discussions], but with limitations:

- Only works with actions from Javascript UI; non Javascript actions will be ignored. This happens in browsers do not support Javascript.
- The title of topics is only displayed as UUID (for instance, `Topic:V2x4eocpudm5wtz4`) rather than a human readable ones.

In addition, my source editor removes some whitespaces automatically. But it affects nothing, don't worry about it.

[Structured Discussions]: https://www.mediawiki.org/wiki/Structured_Discussions