### PR TITLE
Replace & with %26 in $url

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -9,6 +9,7 @@ class DiscordNotifications
 		$url = str_replace(" ", "%20", $url);
 		$url = str_replace("(", "%28", $url);
 		$url = str_replace(")", "%29", $url);
+                $url = str_replace("&", "%26", $url);
 		return $url;
 	}
 


### PR DESCRIPTION
This can cause issues as MediaWiki uses & for parameters at times and it has been reported to cause links to break.

Example: https://cwars.miraheze.org/w/index.php?title=Template:Animation%20&%20Game%20Card where I worked out replacing & with %26 seemed to be the easiest fix