### PR TITLE
Add custom webhook avatars; use bytes, KiB, MiB for uploaded files.

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -455,7 +455,7 @@ class DiscordNotifications
 	 */
 	static function push_discord_notify($message, $user, $action)
 	{
-		global $wgDiscordIncomingWebhookUrl, $wgDiscordFromName, $wgDiscordSendMethod, $wgExcludedPermission, $wgSitename, $wgDiscordAdditionalIncomingWebhookUrls;
+		global $wgDiscordIncomingWebhookUrl, $wgDiscordFromName, $wgDiscordAvatarURL, $wgDiscordSendMethod, $wgExcludedPermission, $wgSitename, $wgDiscordAdditionalIncomingWebhookUrls;
 		
 		if ( $wgExcludedPermission != "" ) {
 			if ( $user->isAllowed( $wgExcludedPermission ) )
@@ -516,6 +516,9 @@ class DiscordNotifications
 		$post = sprintf('{"embeds": [{ "color" : "'.$colour.'" ,"description" : "%s"}], "username": "%s"',
 		$message,
 		$discordFromName);
+		if (isset($wgDiscordAvatarURL) && !empty($wgDiscordAvatarURL)) {
+			$post .= ', "avatar_url": "'.$wgDiscordAvatarURL.'"';
+		}
 		$post .= '}';
 
 		// Use file_get_contents to send the data. Note that you will need to have allow_url_fopen enabled in php.ini for this to work.

--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -305,14 +305,31 @@ class DiscordNotifications
 		if (!$wgDiscordNotificationFileUpload) return;
 
 		global $wgWikiUrl, $wgWikiUrlEnding, $wgUser;
+		$localFile = $image->getLocalFile();
+
+		# Use bytes, KiB, and MiB, rounded to two decimal places.
+		$fsize = $localFile->size;
+		$funits = '';
+		if ($localFile->size < 2048) {
+			$funits = 'bytes';
+		} else if ($localFile->size < 2048*1024) {
+			$fsize /= 1024;
+			$fsize = round($fsize, 2);
+			$funits = 'KiB';
+		} else {
+			$fsize /= 1024*1024;
+			$fsize = round($fsize, 2);
+			$funits = 'MiB';
+		}
+
 		$message = sprintf(
 			self::getMessage('discordnotifications-file-uploaded'),
 			self::getDiscordUserText($wgUser->mName),
 			self::parseurl($wgWikiUrl . $wgWikiUrlEnding . $image->getLocalFile()->getTitle()),
-			$image->getLocalFile()->getTitle(),
-			$image->getLocalFile()->getMimeType(),
-			round($image->getLocalFile()->size / 1024 / 1024, 3),
-			$image->getLocalFile()->getDescription());
+			$localFile->getTitle(),
+			$localFile->getMimeType(),
+			$fsize, $funits,
+			$localFile->getDescription());
 
 		self::push_discord_notify($message, $wgUser, 'file_uploaded');
 		return true;

--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -472,7 +472,7 @@ class DiscordNotifications
 	 */
 	static function push_discord_notify($message, $user, $action)
 	{
-		global $wgDiscordIncomingWebhookUrl, $wgDiscordFromName, $wgDiscordAvatarURL, $wgDiscordSendMethod, $wgExcludedPermission, $wgSitename, $wgDiscordAdditionalIncomingWebhookUrls;
+		global $wgDiscordIncomingWebhookUrl, $wgDiscordFromName, $wgDiscordAvatarUrl, $wgDiscordSendMethod, $wgExcludedPermission, $wgSitename, $wgDiscordAdditionalIncomingWebhookUrls;
 		
 		if ( $wgExcludedPermission != "" ) {
 			if ( $user->isAllowed( $wgExcludedPermission ) )
@@ -533,8 +533,8 @@ class DiscordNotifications
 		$post = sprintf('{"embeds": [{ "color" : "'.$colour.'" ,"description" : "%s"}], "username": "%s"',
 		$message,
 		$discordFromName);
-		if (isset($wgDiscordAvatarURL) && !empty($wgDiscordAvatarURL)) {
-			$post .= ', "avatar_url": "'.$wgDiscordAvatarURL.'"';
+		if (isset($wgDiscordAvatarUrl) && !empty($wgDiscordAvatarUrl)) {
+			$post .= ', "avatar_url": "'.$wgDiscordAvatarUrl.'"';
 		}
 		$post .= '}';
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ require_once("$IP/extensions/DiscordNotifications/DiscordNotifications.php");
 $wgDiscordIncomingWebhookUrl = "";
 // Required. Name the message will appear to be sent from. Change this to whatever you wish it to be.
 $wgDiscordFromName = $wgSitename;
+// Avatar to use for messages. If blank, uses the webhook's default avatar.
+$wgDiscordAvatarUrl = "";
 // URL into your MediaWiki installation with the trailing /.
-$wgWikiUrl		= "http://your_wiki_url/";
+$wgWikiUrl = "http://your_wiki_url/";
 // Wiki script name. Leave this to default one if you do not have URL rewriting enabled.
 $wgWikiUrlEnding = "index.php?title=";
 // What method will be used to send the data to Discord server. By default this is "curl" which only works if you have the curl extension enabled. There have been cases where VisualEditor extension does not work with the curl method, so in that case the recommended solution is to use the file_get_contents method. This can be: "curl" or "file_get_contents". Default: "curl".

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -24,7 +24,7 @@
 	"discordnotifications-article-protected-change": "geändert",
 	"discordnotifications-article-protected-remove": "entfernt",
 	"discordnotifications-new-user": "👥 Neuer Benutzer %s wurde erstellt %s",
-	"discordnotifications-file-uploaded": "📤 %s hat die Datei <%s|%s> hochgeladen (Format: %s, Größe: %s MB, Zusammenfassung: %s)",
+	"discordnotifications-file-uploaded": "📤 %s hat die Datei <%s|%s> hochgeladen (Format: %s, Größe: %s %s, Zusammenfassung: %s)",
 	"discordnotifications-block-user": "🚫 %s sperrt %s %s Sperrung läuft aus: %s. %s",
 	"discordnotifications-block-user-reason": "mit der Begründung",
 	"discordnotifications-block-user-list": "Liste aller Sperrungen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -24,7 +24,7 @@
     "discordnotifications-article-protected-change": "changed protection of",
     "discordnotifications-article-protected-remove": "removed protection of",
     "discordnotifications-new-user": "👥 New user account %s was just created %s",
-    "discordnotifications-file-uploaded": "📤 %s has uploaded file <%s|%s> (format: %s, size: %s MB, summary: %s)",
+    "discordnotifications-file-uploaded": "📤 %s has uploaded file <%s|%s> (format: %s, size: %s %s, summary: %s)",
     "discordnotifications-block-user": "🚫 %s has blocked %s %s Block expiration: %s. %s",
     "discordnotifications-block-user-reason": "with reason",
     "discordnotifications-block-user-list": "List of all blocks",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -24,7 +24,7 @@
     "discordnotifications-article-protected-change": "cambió la protección del",
     "discordnotifications-article-protected-remove": "quitó la protección del",
     "discordnotifications-new-user": "👥 La cuenta de usuario %s fue creada %s",
-    "discordnotifications-file-uploaded": "📤 %s subió un archivo <%s|%s> (formato: %s, tamaño: %s MB, resumen: %s)",
+    "discordnotifications-file-uploaded": "📤 %s subió un archivo <%s|%s> (formato: %s, tamaño: %s %s, resumen: %s)",
     "discordnotifications-block-user": "🚫 %s bloqueó a %s %s Expiración del bloqueo: %s. %s",
     "discordnotifications-block-user-reason": "con motivo",
     "discordnotifications-block-user-list": "Lista de todos los bloqueos",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -24,7 +24,7 @@
     "discordnotifications-article-protected-change": "vaihtoi suojaustason artikkelille",
     "discordnotifications-article-protected-remove": "poisti suojauksen artikkelilta",
     "discordnotifications-new-user": "👥 Uusi tunnus %s luotiin juuri %s",
-    "discordnotifications-file-uploaded": "📤 %s on ladannut tiedoston <%s|%s> (muoto: %s, koko: %s MB, yhteenveto: %s)",
+    "discordnotifications-file-uploaded": "📤 %s on ladannut tiedoston <%s|%s> (muoto: %s, koko: %s %s, yhteenveto: %s)",
     "discordnotifications-block-user": "🚫 %s on estänyt käyttäjän %s %s Esto erääntyy: %s. %s",
     "discordnotifications-block-user-reason": "syy",
     "discordnotifications-block-user-list": "Näytä kaikki estot",


### PR DESCRIPTION
This PR adds two features:
1. New parameter `$wgDiscordAvatarUrl`. If set, this overrides the webhook's default avatar. This is useful if you run multiple wikis and want to use the same webhook for all of them.
2. For uploaded files, use bytes, KiB, and MiB instead of always using MB. Bytes is used if the file size is < 2048 bytes, KiB if < 2048 KiB, and MiB otherwise.