### PR TITLE
Change Content-type for file_get_contents

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -551,7 +551,7 @@ class DiscordNotificationsCore {
 	private static function sendHttpRequest( $url, $postData ) {
 		$extradata = [
 			'http' => [
-			'header'  => "Content-type: application/x-www-form-urlencoded\r\n",
+			'header'  => "Content-type: application/json",
 			'method'  => 'POST',
 			'content' => $postData,
 			],


### PR DESCRIPTION
I don't know exactly what happened: Suddenly, DiscordNotifications did not work for me and this patch has fixed that.