### PR TITLE
Fixed "Cannot send empty message" bug.

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -540,6 +540,11 @@ class DiscordNotificationsCore {
 		curl_setopt( $h, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $h, CURLOPT_CONNECTTIMEOUT, 10 ); // Set 10 second timeout to connection
 		curl_setopt( $h, CURLOPT_TIMEOUT, 10 ); // Set global 10 second timeout to handle all data
+		curl_setopt($h, CURLOPT_HTTPHEADER, array(  
+			'Content-Type: application/json',
+			'Content-Length: ' . strlen($postData)
+		    )    
+		); // Set Content-Type to application/json
 		// Commented out lines below. Using default curl settings for host and peer verification.
 		//curl_setopt ($h, CURLOPT_SSL_VERIFYHOST, 0);
 		//curl_setopt ($h, CURLOPT_SSL_VERIFYPEER, 0);

--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -540,7 +540,7 @@ class DiscordNotificationsCore {
 		curl_setopt( $h, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $h, CURLOPT_CONNECTTIMEOUT, 10 ); // Set 10 second timeout to connection
 		curl_setopt( $h, CURLOPT_TIMEOUT, 10 ); // Set global 10 second timeout to handle all data
-		curl_setopt($h, CURLOPT_HTTPHEADER, array(  
+		curl_setopt( $h, CURLOPT_HTTPHEADER, array(  
 			'Content-Type: application/json',
 			'Content-Length: ' . strlen($postData)
 		    )    


### PR DESCRIPTION
Fixed Discord API responding with "Cannot send empty message" by changing the `Content-Type` to `application/json`

Please comment why this edit might be bad.