### PR TITLE
Make onDiscordArticleInserted a static function

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -143,7 +143,7 @@ class DiscordNotificationsCore {
 	 * Occurs after a new article has been created.
 	 * @see http://www.mediawiki.org/wiki/Manual:Hooks/ArticleInsertComplete
 	 */
-	public function onDiscordArticleInserted( WikiPage $article, $user, $text, $summary, $isminor, $iswatch, $section, $flags, $revision ) {
+	public static function onDiscordArticleInserted( WikiPage $article, $user, $text, $summary, $isminor, $iswatch, $section, $flags, $revision ) {
 		global $wgDiscordNotificationAddedArticle, $wgDiscordIncludeDiffSize;
 		if ( !$wgDiscordNotificationAddedArticle ) return;
 


### PR DESCRIPTION
extension.json#hooks calls onDiscordArticleInserted as a static function thus you get:

ErrorException from line 174 of /srv/mediawiki/w/includes/Hooks.php: PHP Deprecated: Non-static method DiscordNotificationsCore::onDiscordArticleInserted() should not be called statically