### PR TITLE
Remove $wgExcludedPermission from extension.json

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -448,7 +448,7 @@ class DiscordNotificationsCore {
 	private static function pushDiscordNotify( $message, $user, $action ) {
 		global $wgDiscordIncomingWebhookUrl, $wgDiscordFromName, $wgDiscordAvatarUrl, $wgDiscordSendMethod, $wgExcludedPermission, $wgSitename, $wgDiscordAdditionalIncomingWebhookUrls;
 
-		if ( $wgExcludedPermission != "" ) {
+		if ( isset( $wgExcludedPermission ) && $wgExcludedPermission != "" ) {
 			if ( $user->isAllowed( $wgExcludedPermission ) ) {
 				return; // Users with the permission suppress notifications
 			}

--- a/extension.json
+++ b/extension.json
@@ -73,7 +73,6 @@
 		"DiscordIncludePageUrls": true,
 		"DiscordIncludeUserUrls": true,
 		"DiscordIgnoreMinorEdits": false,
-		"ExcludedPermission": "",
 		"DiscordExcludeNotificationsFrom": [],
 		"WikiUrl": "",
 		"WikiUrlEnding": "index.php?title=",


### PR DESCRIPTION
This cannot be defined in both the Discord and Slack extension. To work around this we use the isset() check.