### PR TITLE
Fix config (wgDiscordAdditionalIncomingWebhookUrls -> DiscordAdditionalIncomingWebhookUrls)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -67,7 +67,7 @@
 	},
 	"config": {
 		"DiscordIncomingWebhookUrl": "",
-		"wgDiscordAdditionalIncomingWebhookUrls": [],
+		"DiscordAdditionalIncomingWebhookUrls": [],
 		"DiscordFromName": "",
 		"DiscordSendMethod": "curl",
 		"DiscordIncludePageUrls": true,


### PR DESCRIPTION
When setting wgDiscordAdditionalIncomingWebhookUrls in extension.json it has to minus the wg prefix as it's automatically added.

Currently this makes the config wgwgDiscordAdditionalIncomingWebhookUrls which is not what we want.