### PR TITLE
 Treat passed user input as plaintext

### DIFF
--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -125,12 +125,12 @@ class DiscordNotificationsCore {
 			return;
 		}
 
-		$message = self::msg(
-			'discordnotifications-article-saved',
+		$message = wfMessage( 'discordnotifications-article-saved' )->plaintextParams(
 			self::getDiscordUserText( $user ),
 			$isMinor == true ? self::msg( 'discordnotifications-article-saved-minor-edits' ) : self::msg( 'discordnotifications-article-saved-edit' ),
 			self::getDiscordArticleText( $article, true ),
-			$summary == "" ? "" : self::msg( 'discordnotifications-summary', $summary ) );
+			$summary == "" ? "" : wfMessage( 'discordnotifications-summary', $summary )->inContentLanguage()->plain()
+		)->inContentLanguage()->text();
 		if ( $wgDiscordIncludeDiffSize ) {
 			$message .= ' (' . self::msg( 'discordnotifications-bytes',
 				$article->getRevision()->getSize() - $article->getRevision()->getPrevious()->getSize() ) . ')';
@@ -158,10 +158,11 @@ class DiscordNotificationsCore {
 		// Do not announce newly added file uploads as articles...
 		if ( $article->getTitle()->getNsText() == self::msg( 'discordnotifications-file-namespace' ) ) return true;
 
-		$message = self::msg( 'discordnotifications-article-created',
+		$message = wfMessage( 'discordnotifications-article-created' )->plaintextParams(
 			self::getDiscordUserText( $user ),
 			self::getDiscordArticleText( $article ),
-			$summary == "" ? "" : self::msg( 'discordnotifications-summary', $summary ) );
+			$summary == "" ? "" : wfMessage( 'discordnotifications-summary', $summary )->inContentLanguage()->plain()
+		)->inContentLanguage()->text();
 		if ( $wgDiscordIncludeDiffSize ) {
 			$message .= " (" . self::msg( 'discordnotifications-bytes', $article->getRevision()->getSize() ) . ")";
 		}
@@ -188,10 +189,11 @@ class DiscordNotificationsCore {
 			}
 		}
 
-		$message = self::msg( 'discordnotifications-article-deleted',
+		$message = wfMessage( 'discordnotifications-article-deleted' )->plaintextParams(
 			self::getDiscordUserText( $user ),
 			self::getDiscordArticleText( $article ),
-			$reason );
+			$reason
+		)->inContentLanguage()->text();
 		self::pushDiscordNotify( $message, $user, 'article_deleted' );
 		return true;
 	}

--- a/DiscordNotificationsCore.php
+++ b/DiscordNotificationsCore.php
@@ -234,12 +234,12 @@ class DiscordNotificationsCore {
 	 * Occurs after page has been imported into wiki.
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/AfterImportPage
 	 */
-	public static function onDiscordAfterImportPage( $title = null, $origTitle = Null, $revCount = null, $sRevCount = null, $pageInfo = null ) {
+	public static function onDiscordAfterImportPage( $title = null, $origTitle = null, $revCount = null, $sRevCount = null, $pageInfo = null ) {
 		global $wgDiscordNotificationAfterImportPage;
 		if ( !$wgDiscordNotificationAfterImportPage ) return;
-		
+
 		$message = self::msg( 'discordnotifications-import-complete',
-			self::getDiscordTitleText( $title ));
+			self::getDiscordTitleText( $title ) );
 		self::pushDiscordNotify( $message, null, 'import_complete' );
 		return true;
 	}
@@ -250,7 +250,7 @@ class DiscordNotificationsCore {
 	 */
 	public static function onDiscordNewUserAccount( $user, $byEmail ) {
 		global $wgDiscordNotificationNewUser, $wgDiscordShowNewUserFullName;
-		
+
 		// Disable reporting of new user email and IP address
 		//global $wgDiscordShowNewUserEmail, $wgDiscordShowNewUserIP;
 		$wgDiscordShowNewUserEmail = false;
@@ -335,7 +335,7 @@ class DiscordNotificationsCore {
 
 		global $wgDiscordNotificationWikiUrl, $wgDiscordNotificationWikiUrlEnding, $wgDiscordNotificationWikiUrlEndingBlockList;
 		$mReason = "";
-		if (defined('MW_VERSION') && version_compare(MW_VERSION, '1.35', '>=')) {  //DatabaseBlock::$mReason was made protected in MW 1.35
+		if ( defined( 'MW_VERSION' ) && version_compare( MW_VERSION, '1.35', '>=' ) ) {  // DatabaseBlock::$mReason was made protected in MW 1.35
 			$mReason = $block->getReasonComment()->text;
 		} else {
 			$mReason = $block->mReason;
@@ -475,7 +475,7 @@ class DiscordNotificationsCore {
 		global $wgDiscordIncomingWebhookUrl, $wgDiscordFromName, $wgDiscordAvatarUrl, $wgDiscordSendMethod, $wgDiscordExcludedPermission, $wgSitename, $wgDiscordAdditionalIncomingWebhookUrls;
 
 		if ( isset( $wgDiscordExcludedPermission ) && $wgDiscordExcludedPermission != "" ) {
-			if ($user && $user->isAllowed( $wgDiscordExcludedPermission ) ) {
+			if ( $user && $user->isAllowed( $wgDiscordExcludedPermission ) ) {
 				return; // Users with the permission suppress notifications
 			}
 		}
@@ -566,11 +566,10 @@ class DiscordNotificationsCore {
 		curl_setopt( $h, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $h, CURLOPT_CONNECTTIMEOUT, 10 ); // Set 10 second timeout to connection
 		curl_setopt( $h, CURLOPT_TIMEOUT, 10 ); // Set global 10 second timeout to handle all data
-		curl_setopt( $h, CURLOPT_HTTPHEADER, array(  
+		curl_setopt( $h, CURLOPT_HTTPHEADER, [
 			'Content-Type: application/json',
-			'Content-Length: ' . strlen($postData)
-		    )    
-		); // Set Content-Type to application/json
+			'Content-Length: ' . strlen( $postData )
+		] ); // Set Content-Type to application/json
 		// Commented out lines below. Using default curl settings for host and peer verification.
 		//curl_setopt ($h, CURLOPT_SSL_VERIFYHOST, 0);
 		//curl_setopt ($h, CURLOPT_SSL_VERIFYPEER, 0);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28209361/98435744-d9af2d00-2118-11eb-807e-de5a45db284c.png)

`Message::plaintextParams()`: Like rawParams(), but does escaping. It is useful when you pass user input that may contain wikitext that should not be parsed.<sup>[Manual:Messages API](https://www.mediawiki.org/wiki/Manual:Messages_API#Parameters)</sup>


Related to https://github.com/kulttuuri/DiscordNotifications/issues/73