### PR TITLE
Add default value for WikiUrlEndingBlockList

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -83,6 +83,7 @@
 		"DiscordNotificationWikiUrl": "",
 		"DiscordNotificationWikiUrlEnding": "index.php?title=",
 		"DiscordNotificationWikiUrlEndingUserRights": "Special%3AUserRights&user=",
+		"DiscordNotificationWikiUrlEndingBlockList": "Special:BlockList",
 		"DiscordNotificationWikiUrlEndingBlockUser": "Special:Block/",
 		"DiscordNotificationWikiUrlEndingUserPage": "User:",
 		"DiscordNotificationWikiUrlEndingUserTalkPage": "User_talk:",


### PR DESCRIPTION
Fixes "List of all blocks" link leading to the main page by default